### PR TITLE
Add missed functions

### DIFF
--- a/src/packaging/add-launch-to-msi.js
+++ b/src/packaging/add-launch-to-msi.js
@@ -25,3 +25,48 @@ try {
     WScript.StdErr.WriteLine(e);
     WScript.Quit(1);
 }
+
+// Finds file id and component id of file
+function FindFileIdentifier(database, fileName) {
+    var sql
+    var view
+    var record
+
+    // First, try to find the exact file name
+    sql = "SELECT `File`, `Component_` FROM `File` WHERE `FileName`='" + fileName + "'";
+    view = database.OpenView(sql);
+    view.Execute();
+    record = view.Fetch();
+    if (record) {
+        var value = record.StringData(1);
+        componentId = record.StringData(2)
+        view.Close();
+        return value;
+    }
+    view.Close();
+
+    // The file may be in SFN|LFN format.  Look for a filename in this case next
+    sql = "SELECT `File`, `Component_`, `FileName` FROM `File`";
+    view = database.OpenView(sql);
+    view.Execute();
+    record = view.Fetch();
+    while (record) {
+        if (StringEndsWith(record.StringData(3), "|" + fileName)) {
+            componentId = record.StringData(2);
+            var value = record.StringData(1);
+            view.Close();
+            return value;
+        }
+
+        record = view.Fetch();
+    }
+    view.Close();
+
+}
+
+function StringEndsWith(str, value) {
+    if (str.length < value.length)
+        return false;
+
+    return (str.indexOf(value, str.length - value.length) != -1);
+}


### PR DESCRIPTION
Without these functions, auto start after installing msi don't work. 
Script fails with error:
> add-launch-to-msi.js(8, 1) Microsoft JScript runtime error: Object expected