### PR TITLE
Include only compile stage dependencies (no test dependencies)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,8 @@
                             <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
+                            <!-- Include only compile stage dependencies (no test dependencies) -->
+                            <includeScope>compile</includeScope>
                             <!-- The JavaFX libraries are bundled into the custom JVM, so we don't want to duplicate
                             them in the bundled app and installer. This command skips all of the JavaFX by groupId. -->
                             <excludeGroupIds>org.openjfx</excludeGroupIds>


### PR DESCRIPTION
Bundle JUnit to installer is unnecessary